### PR TITLE
Update step-security/harden-runner to v2.14.2

### DIFF
--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: block
           disable-sudo: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           disable-sudo: true
           egress-policy: block


### PR DESCRIPTION
Updates step-security/harden-runner to v2.14.2 as recommended by zizmor audit.

This was developed with the assistance of Kiro.dev